### PR TITLE
테스트 실패 코드 수정 및 엔티티 변환 메서드 추가 (#4)

### DIFF
--- a/src/main/java/com/hyunbenny/bookroom/dto/UserAccountDto.java
+++ b/src/main/java/com/hyunbenny/bookroom/dto/UserAccountDto.java
@@ -40,6 +40,9 @@ public record UserAccountDto(
                 );
     }
 
+    public UserAccount toEntity() {
+        return UserAccount.of(userId, name, nickname, password, email, phone);
+    }
     public UserAccount toEntity(String encodedPassword) {
         return UserAccount.of(userId, name, nickname, encodedPassword, email, phone);
     }

--- a/src/test/java/com/hyunbenny/bookroom/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/hyunbenny/bookroom/controller/UserAccountControllerTest.java
@@ -62,8 +62,9 @@ class UserAccountControllerTest {
         mvc.perform(post("/join")
                         .content(formDataEncoder.encode(joinRequest))
                 )
-                .andExpect(view().name("redirect:/login"))
-                .andExpect(redirectedUrl("/login"));
+                .andExpect(view().name("message"))
+                .andExpect(model().attribute("message", "성공적으로 회원가입하였습니다."))
+                .andExpect(model().attribute("url", "/login"));
     }
 
     @DisplayName("[POST] join: 회원가입 요청시, 이미 존재하는 아이디로 요청하면 다시 회원가입 페이지로 이동한다.")

--- a/src/test/java/com/hyunbenny/bookroom/dto/request/JoinRequestTest.java
+++ b/src/test/java/com/hyunbenny/bookroom/dto/request/JoinRequestTest.java
@@ -45,7 +45,7 @@ class JoinRequestTest {
         String userId = "testUser90";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -73,7 +73,7 @@ class JoinRequestTest {
         String userId = "abcde";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -101,7 +101,7 @@ class JoinRequestTest {
         String userId = "1234567890123456789";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -129,7 +129,7 @@ class JoinRequestTest {
         String userId = "";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -158,7 +158,7 @@ class JoinRequestTest {
         String userId = " ";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -187,7 +187,7 @@ class JoinRequestTest {
         String userId = "테스트유저아이디";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -216,7 +216,7 @@ class JoinRequestTest {
         String userId = "abcd";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -245,7 +245,7 @@ class JoinRequestTest {
         String userId = "abcdefghijklmnopqrstuvwxyz";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -275,7 +275,7 @@ class JoinRequestTest {
         String userId = "helloWorld!";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -305,7 +305,7 @@ class JoinRequestTest {
         String userId = "helloWorld@";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -335,7 +335,7 @@ class JoinRequestTest {
         String userId = "helloWorld#";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -365,7 +365,7 @@ class JoinRequestTest {
         String userId = "helloWorld$";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -395,7 +395,7 @@ class JoinRequestTest {
         String userId = "helloWorld%";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -425,7 +425,7 @@ class JoinRequestTest {
         String userId = "helloWorld^";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -455,7 +455,7 @@ class JoinRequestTest {
         String userId = "helloWorld&";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -485,7 +485,7 @@ class JoinRequestTest {
         String userId = "helloWorld*";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -515,7 +515,7 @@ class JoinRequestTest {
         String userId = "helloWorld(";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -545,7 +545,7 @@ class JoinRequestTest {
         String userId = "helloWorld)";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -575,7 +575,7 @@ class JoinRequestTest {
         String userId = "helloWorld-";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -605,7 +605,7 @@ class JoinRequestTest {
         String userId = "helloWorld_";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -635,7 +635,7 @@ class JoinRequestTest {
         String userId = "helloWorld+";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -665,7 +665,7 @@ class JoinRequestTest {
         String userId = "helloWorld=";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -695,7 +695,7 @@ class JoinRequestTest {
         String userId = "helloWorld<";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -725,7 +725,7 @@ class JoinRequestTest {
         String userId = "helloWorld>";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -755,7 +755,7 @@ class JoinRequestTest {
         String userId = "helloWorld?";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -785,7 +785,7 @@ class JoinRequestTest {
         String userId = "helloWorld,";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -815,7 +815,7 @@ class JoinRequestTest {
         String userId = "helloWorld.";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -845,7 +845,7 @@ class JoinRequestTest {
         String userId = "helloWorld/";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",
@@ -875,7 +875,7 @@ class JoinRequestTest {
         String userId = "hello World";
         JoinRequest joinRequest = JoinRequest.of(
                 userId,
-                "name",
+                "김테스터",
                 "nickname",
                 "Password12!@!@",
                 "test@email.com",

--- a/src/test/java/com/hyunbenny/bookroom/service/UserAccountServiceTest.java
+++ b/src/test/java/com/hyunbenny/bookroom/service/UserAccountServiceTest.java
@@ -42,7 +42,7 @@ class UserAccountServiceTest {
         UserAccountDto userAccountDto = createUserAccountDto();
         UserAccount userAccountEntity = createUserAccountEntity();
         // when
-        when(userAccountRepository.findById("testUserId")).thenReturn(Optional.empty());
+        when(userAccountRepository.findByIdWithoutDeletedAtCondition("testUserId")).thenReturn(Optional.empty());
         when(passwordEncoder.encode(any(String.class))).thenReturn("encodedPassword");
         when(userAccountRepository.save(any())).thenReturn(userAccountEntity);
 
@@ -56,8 +56,9 @@ class UserAccountServiceTest {
     @Test
     void given_alreadyExistUserId_when_requestJoin_then_returnException() {
         // given
+        String userId = "testUserId";
         UserAccountDto userAccountDto = createUserAccountDto();
-        given(userAccountRepository.findById(any())).willReturn(Optional.of(createUserAccountEntity()));
+        given(userAccountRepository.findByIdWithoutDeletedAtCondition(userId)).willReturn(Optional.of(createUserAccountEntity()));
 
         // when & then
         UserAlreadyExistException exception = assertThrows(UserAlreadyExistException.class, () -> userAccountService.join(userAccountDto));


### PR DESCRIPTION
실패하는 테스트 코드를 수정하였고  UserAccountDto에서 UserEntity로 변환하는 메서드 추가

- UserAccountControllerTest: 리다이렉트를 `message`에서 동작시킴으로써 발생한 테스트 실패 코드 수정
- JoinRequestTest: `userId`테스트 시에  `name`의 유효성 검사를 통과 하지 못해 발생한 실패 코드 수정
- UserAccountServiceTest: 회원가입 시 `delete_at` 조건 없이 모든 회원에 대해서 조회를 해와야 하는데 로직은 수정하고 테스트코드는 수정하지 않아 UserAccountRepository의 조회 메서드 수정
- 기존 메서드는 회원가입 시에만 생각한 toEntity()메서드였는데 회원을 조회한 후 다시 엔티티로 변환하는 경우에도 필요하여 toEntity()를 오버라이딩 함

This closes #4.
